### PR TITLE
force compilation with -ansi and remove faulty // style comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(CSpice::cspice ALIAS cspice)
 # Silence warnings.'
 if(NOT MSVC)
     set_property(TARGET cspice APPEND PROPERTY COMPILE_OPTIONS
+            "-ansi"
             "-Wno-implicit-int"
             "-Wunused-result"
             "-Wno-incompatible-pointer-types"

--- a/src/cspice/sys/times.h
+++ b/src/cspice/sys/times.h
@@ -1,4 +1,4 @@
-// From http://www.linuxjournal.com/article/5574
+/* From http://www.linuxjournal.com/article/5574 */
 
 #ifndef _TIMES_H
 #define _TIMES_H
@@ -10,9 +10,10 @@
 
 int gettimeofday(struct timeval* t,void* timezone);
 
-// from linux's sys/times.h
+/* from linux's sys/times.h
 
-//#include <features.h>
+#include <features.h>
+*/
 
 #define __need_clock_t
 #include <time.h>


### PR DESCRIPTION
To compile this (with GCC 15 on Fedora 42) I had to force a "-ansi" argument and change comment style in `src/cspice/sys/times.h`. I'm not too familiar with CMake, so maybe the "-ansi" argument should go somewhere else.